### PR TITLE
Allow django-ratelimit to use Axes+Ipware for ip

### DIFF
--- a/donate_anything/users/apps.py
+++ b/donate_anything/users/apps.py
@@ -7,7 +7,22 @@ class UsersConfig(AppConfig):
     verbose_name = _("Users")
 
     def ready(self):
+        patch_rate_limit()
         try:
             import donate_anything.users.signals  # noqa F401
         except ImportError:
             pass
+
+
+# noinspection PyPackageRequirements,PyProtectedMember
+def patch_rate_limit():
+    from axes.utils import get_client_ip_address
+    from ratelimit.core import _SIMPLE_KEYS, ip_mask
+
+    def user_or_ip(request):
+        if request.user.is_authenticated:
+            return str(request.user.pk)
+        return ip_mask(get_client_ip_address(request))
+
+    _SIMPLE_KEYS["ip"] = lambda r: ip_mask(get_client_ip_address(r))
+    _SIMPLE_KEYS["user_or_ip"] = user_or_ip

--- a/donate_anything/users/apps.py
+++ b/donate_anything/users/apps.py
@@ -16,7 +16,7 @@ class UsersConfig(AppConfig):
 
 # noinspection PyPackageRequirements,PyProtectedMember
 def patch_rate_limit():
-    from axes.utils import get_client_ip_address
+    from axes.helpers import get_client_ip_address
     from ratelimit.core import _SIMPLE_KEYS, ip_mask
 
     def user_or_ip(request):


### PR DESCRIPTION
* First used for Velnota. Initial testing for throttling using django ratelimit
* The following gist Andrew made goes a little more in detail to this implementation: https://gist.github.com/Andrew-Chen-Wang/bd30e31211ec8c1046886877e137cdf5